### PR TITLE
Fix typo preventing file write.

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -423,9 +423,9 @@ trait IntegrationTrait
 
         if (! is_dir($outputDir)) {
             mkdir($outputDir, 0777, true);
-
-            file_put_contents("{$outputDir}/output.txt", $this->content());
         }
+
+        file_put_contents("{$outputDir}/output.txt", $this->content());
     }
 
     /**


### PR DESCRIPTION
The file is written only when the 'logs' directory does not exist.
