### PR TITLE
Add method spoofing when submitting forms

### DIFF
--- a/src/Extensions/Laravel.php
+++ b/src/Extensions/Laravel.php
@@ -144,4 +144,15 @@ abstract class Laravel extends TestCase implements Emulator
 
         throw new PHPUnitException($message);
     }
+
+    /**
+     * Enable method spoofing for HTML forms with a "_method" attribute.
+     *
+     * @see Symfony\Component\HttpFoundation\Request::enableHttpMethodParameterOverride()
+     * @setUp
+     */
+    protected function enableMethodSpoofing()
+    {
+        $this->app['request']->enableHttpMethodParameterOverride();
+    }
 }


### PR DESCRIPTION
By default, [method spoofing](http://laravel.com/docs/master/routing#method-spoofing) is disabled in test cases. As a result, when trying to submit a form with a method other than `GET` or `POST`, you're gonna end up with a 405 response, and in my case, too much time lost in figuring out why.

This adds a setup method using an annotation, enabling method spoofing. I think it'll also prevent some future issues/laracasts posts from others wondering about this.
