### PR TITLE
Remove trailing slash on urls

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -89,7 +89,7 @@ trait IntegrationTrait
         }
 
         if (! Str::startsWith($url, 'http')) {
-            $url = sprintf("%s/%s", $this->baseUrl(), $url);
+            $url = rtrim(sprintf("%s/%s", $this->baseUrl(), $url), '/');
         }
 
         return $url;


### PR DESCRIPTION
When you call `seePageIs('/')` it will fail even though you are on the right page because the `prepareUrl` method will leave a trailing slash on `currentUrl`
