### PR TITLE
'fill' is now an alias of 'type' method.

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -195,7 +195,7 @@ trait IntegrationTrait
      */
     public function type($text, $element)
     {
-        return $this->fill($text, $element);
+        return $this->storeInput($element, $text);
     }
 
     /**
@@ -207,7 +207,7 @@ trait IntegrationTrait
      */
     public function fill($text, $element)
     {
-        return $this->storeInput($element, $text);
+        return $this->type($text, $element);
     }
 
     /**


### PR DESCRIPTION
Hello Jeffrey.
As specified in the docblock of the `fill` method, it sould be an alias of `type`. But it was the opposite, `type` was an alias of `fill`. 
This was causing an issue on the Selenium driver cause the `type` method overwritten in it, and people using `fill` with Selenium in their tests would not have their inputs filled properly.
