### PR TITLE
Escape see($text). Resolves #24

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -108,7 +108,7 @@ trait IntegrationTrait
                 "Could not find '%s' on the page, '%s'.", $text, $this->currentPage
             );
 
-            $text = preg_quote($text);
+            $text = preg_quote($text, '/');
 
             $this->assertRegExp("/{$text}/i", $this->response(), $message);
         } catch (PHPUnitException $e) {
@@ -126,7 +126,7 @@ trait IntegrationTrait
      * @param  string $regex
      * @return static
      */
-    public function seeRegularExpression($regex)
+    public function seeRegEx($regex)
     {
         try {
             $message = sprintf(

--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -108,7 +108,32 @@ trait IntegrationTrait
                 "Could not find '%s' on the page, '%s'.", $text, $this->currentPage
             );
 
+            $text = preg_quote($text);
+
             $this->assertRegExp("/{$text}/i", $this->response(), $message);
+        } catch (PHPUnitException $e) {
+            $this->logLatestContent();
+
+            throw $e;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Search the DOM for the given regular expression.
+     *
+     * @param  string $regex
+     * @return static
+     */
+    public function seeRegularExpression($regex)
+    {
+        try {
+            $message = sprintf(
+                "Could not find regex '%s' on the page, '%s'.", $regex, $this->currentPage
+            );
+
+            $this->assertRegExp("/{$regex}/i", $this->response(), $message);
         } catch (PHPUnitException $e) {
             $this->logLatestContent();
 


### PR DESCRIPTION
Unless the original was an intended behavior. It doesn't feel logical to me, because it doesn't "see" what I asked it to "see" if there are certain characters included.

Added new function seeRegularExpression($regex) so the original behavior is still available, if needed.
