### PR TITLE
Restore Missing Import

### DIFF
--- a/src/Extensions/Traits/LaravelTestCase.php
+++ b/src/Extensions/Traits/LaravelTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Laracasts\Integrated\Extensions\Traits;
 
+use PHPUnit_Framework_ExpectationFailedException as PHPUnitException;
 use Laracasts\Integrated\Extensions\Traits\WorksWithDatabase;
 use Laracasts\Integrated\Extensions\Traits\ApiRequests;
 use Laracasts\Integrated\Extensions\IntegrationTrait;


### PR DESCRIPTION
I think this import got missed when extracted to a trait.
