### PR TITLE
Reverse order of execution for teardown methods

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -691,7 +691,7 @@ trait IntegrationTrait
     public function tearDown()
     {
         $this->callMethods(
-            $this->getAnnotations()->having('tearDown')
+            array_reverse($this->getAnnotations()->having('tearDown'))
         );
     }
 


### PR DESCRIPTION
This will allow us to use Laravel and Selenium in `@teardown` annotated methods. Right now `tearDownLaravel` and `closeBrowser` is called before any user defined methods.
