### PR TITLE
Accept data for the delete method

### DIFF
--- a/src/Extensions/Traits/ApiRequests.php
+++ b/src/Extensions/Traits/ApiRequests.php
@@ -86,7 +86,7 @@ trait ApiRequests
      * @param  string $uri
      * @return static
      */
-    protected function delete($uri, array $data)
+    protected function delete($uri, array $data = [])
     {
         $this->call('DELETE', $uri, $data, [], [], $this->headers);
 

--- a/src/Extensions/Traits/ApiRequests.php
+++ b/src/Extensions/Traits/ApiRequests.php
@@ -86,9 +86,9 @@ trait ApiRequests
      * @param  string $uri
      * @return static
      */
-    protected function delete($uri)
+    protected function delete($uri, array $data)
     {
-        $this->call('DELETE', $uri, [], [], [], $this->headers);
+        $this->call('DELETE', $uri, $data, [], [], $this->headers);
 
         return $this;
     }


### PR DESCRIPTION
I thought DELETE method should not contain body data as per the spec, but the spec does not discourage it either.

http://tools.ietf.org/html/draft-ietf-httpbis-p2-semantics-26

I came across a use-case where I need to send body data for the DELETE method. 
