### PR TITLE
Use imperative form for negations

### DIFF
--- a/src/Emulator.php
+++ b/src/Emulator.php
@@ -26,7 +26,7 @@ interface Emulator
      * @param  string $text
      * @return static
      */
-    public function notSee($text);
+    public function dontSee($text);
 
     /**
      * Assert that the page uri is.
@@ -42,7 +42,7 @@ interface Emulator
      * @param  string $page
      * @return static
      */
-    public function notSeePageIs($page);
+    public function dontSeePageIs($page);
 
     /**
      * Assert that the current page is...
@@ -151,7 +151,7 @@ interface Emulator
      * @param  string $path
      * @return static
      */
-    public function notSeeFile($path);
+    public function dontSeeFile($path);
 
     /**
      * Ensure that a database table contains a row with the given data.
@@ -169,7 +169,7 @@ interface Emulator
      * @param  array  $data
      * @return static
      */
-    public function notSeeInDatabase($table, array $data);
+    public function dontSeeInDatabase($table, array $data);
 
     /**
      * Convenience method that defers to seeInDatabase.
@@ -181,13 +181,13 @@ interface Emulator
     public function verifyInDatabase($table, array $data);
 
     /**
-     * Convenience method that defers to notSeeInDatabase.
+     * Convenience method that defers to dontSeeInDatabase.
      *
      * @param  string $table
      * @param  array $data
      * @return static
      */
-    public function notVerifyInDatabase($table, array $data);
+    public function dontVerifyInDatabase($table, array $data);
 
     /**
      * Dump the response content from the last request to the console.

--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -149,7 +149,7 @@ trait IntegrationTrait
      * @return static
      * @throws PHPUnitException
      */
-    protected function notSee($text)
+    protected function dontSee($text)
     {
         return $this->assertSee($text, sprintf(
             "Could not find '%s' on the page, '%s'.", $text, $this->currentPage
@@ -194,7 +194,7 @@ trait IntegrationTrait
      * @param  string $uri
      * @return static
      */
-    protected function notSeePageIs($uri)
+    protected function dontSeePageIs($uri)
     {
         return $this->assertPageIs(
             $uri, "Expected to NOT be on the page, {$uri}, but was.", true
@@ -482,7 +482,7 @@ trait IntegrationTrait
      * @param  string $path
      * @return static
      */
-    protected function notSeeFile($path)
+    protected function dontSeeFile($path)
     {
         $this->assertFileNotExists($path);
 
@@ -530,7 +530,7 @@ trait IntegrationTrait
      * @param  array  $data
      * @return static
      */
-    protected function notSeeInDatabase($table, array $data)
+    protected function dontSeeInDatabase($table, array $data)
     {
         return $this->assertInDatabase($table, $data, sprintf(
             "Found row(s) in the '%s' table that matched the attributes '%s', but did not expect to.",
@@ -551,13 +551,13 @@ trait IntegrationTrait
     }
 
     /**
-     * Alias that defers to notSeeInDatabase.
+     * Alias that defers to dontSeeInDatabase.
      *
      * @param  string $table
      * @param  array  $data
      * @return static
      */
-    protected function notVerifyInDatabase($table, array $data)
+    protected function dontVerifyInDatabase($table, array $data)
     {
         return $this->notSeeInDatabase($table, $data);
     }


### PR DESCRIPTION
Basically just converted all "not" to "dont", since it makes for a more fluent interface.

Imperative:
- Hey, visit /home!
- Hey, fill in "foo"!
- Hey, don't see a 404!

Present:
- I visit /home
- I fill in "foo"
- I don't see a 404

This is what the Laravel community is all about, right? :)
