### PR TITLE
assert true within seeJsonContains

### DIFF
--- a/src/Extensions/Traits/ApiRequests.php
+++ b/src/Extensions/Traits/ApiRequests.php
@@ -181,6 +181,8 @@ trait ApiRequests
             }
         }
         
+        $this->assertTrue(true);
+        
         return $this;
     }
 


### PR DESCRIPTION
fixes the lack of assertion demonstrated here https://github.com/laracasts/Integrated/issues/75
