### PR TITLE
Possibility to pass parameters to a GET request

### DIFF
--- a/src/Extensions/Traits/ApiRequests.php
+++ b/src/Extensions/Traits/ApiRequests.php
@@ -20,9 +20,9 @@ trait ApiRequests
      * @param  string $uri
      * @return static
      */
-    protected function get($uri)
+    protected function get($uri, array $params = array())
     {
-        $this->call('GET', $uri, [], [], [], $this->headers);
+        $this->call('GET', $uri, $params, [], [], $this->headers);
 
         return $this;
     }


### PR DESCRIPTION
It’d be good to have the possibility to pass parameters to a get
request (just like we do with post, put, etc.).

this way, we can use:

``` php
$this->get(‘url/foo’, [‘param1’ => ‘value’, ‘param2’ => ‘value2’]);
```
