### PR TITLE
Submit array fields

### DIFF
--- a/src/Extensions/Traits/LaravelTestCase.php
+++ b/src/Extensions/Traits/LaravelTestCase.php
@@ -99,7 +99,7 @@ trait LaravelTestCase
     protected function makeRequestUsingForm(Form $form)
     {
         return $this->makeRequest(
-            $form->getMethod(), $form->getUri(), $form->getValues(), [], $form->getFiles()
+            $form->getMethod(), $form->getUri(), $form->getPhpValues(), [], $form->getFiles()
         );
     }
 


### PR DESCRIPTION
`$this->submitForm('Add', ['group' => [1 => 2, 3 => 4]])` works with this fix.

The original solution came from https://github.com/laracasts/Integrated/pull/26, but the function is been replaced in a trait.
