### PR TITLE
adding config option for selenium host

### DIFF
--- a/src/Extensions/Selenium.php
+++ b/src/Extensions/Selenium.php
@@ -449,7 +449,9 @@ abstract class Selenium extends \PHPUnit_Framework_TestCase implements Emulator,
      */
     protected function newSession()
     {
-        $host = 'http://localhost:4444/wd/hub';
+        $config = $this->getPackageConfig();
+
+        $host = isset($config['selenium']['host'])) ? $config['selenium']['host'] : 'http://localhost:4444/wd/hub';
 
         $this->webDriver = new WebDriver($host);
         $capabilities = [];

--- a/src/Extensions/Selenium.php
+++ b/src/Extensions/Selenium.php
@@ -451,7 +451,7 @@ abstract class Selenium extends \PHPUnit_Framework_TestCase implements Emulator,
     {
         $config = $this->getPackageConfig();
 
-        $host = isset($config['selenium']['host'])) ? $config['selenium']['host'] : 'http://localhost:4444/wd/hub';
+        $host = isset($config['selenium']['host']) ? $config['selenium']['host'] : 'http://localhost:4444/wd/hub';
 
         $this->webDriver = new WebDriver($host);
         $capabilities = [];


### PR DESCRIPTION
Hey Jeffery,

It might be nice for homestead (and other) users if they could run selenium on a remote host. To do this one might change the integrated.json config to have

```
selenium: {
  browser: firefox
  host: http://someotherhost/wd/hub
}
```

This change would allow for that configuration option seen above.
