### PR TITLE
support for upload file testing

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -10,6 +10,7 @@ use Laracasts\Integrated\File;
 use Laracasts\Integrated\Str;
 use InvalidArgumentException;
 use BadMethodCallException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait IntegrationTrait
 {
@@ -33,6 +34,13 @@ trait IntegrationTrait
      * @var array
      */
     protected $inputs = [];
+
+    /**
+     * User-filled form file uploads.
+     *
+     * @var array
+     */
+    protected $files = [];
 
     /**
      * The user-provided package configuration.
@@ -319,6 +327,9 @@ trait IntegrationTrait
      */
     public function attachFile($element, $absolutePath)
     {
+        $name = str_replace('#', '', $element);
+        $this->files[$name] = $absolutePath;
+
         return $this->storeInput($element, $absolutePath);
     }
 
@@ -570,6 +581,7 @@ trait IntegrationTrait
     protected function clearInputs()
     {
         $this->inputs = [];
+        $this->files = [];
 
         return $this;
     }

--- a/src/Extensions/Traits/LaravelTestCase.php
+++ b/src/Extensions/Traits/LaravelTestCase.php
@@ -8,6 +8,7 @@ use Laracasts\Integrated\Extensions\Traits\ApiRequests;
 use Laracasts\Integrated\Extensions\IntegrationTrait;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Form;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 trait LaravelTestCase
 {
@@ -98,10 +99,13 @@ trait LaravelTestCase
      */
     protected function makeRequestUsingForm(Form $form)
     {
+        $formFiles = $this->convertFormFiles($form);
+
         return $this->makeRequest(
-            $form->getMethod(), $form->getUri(), $form->getPhpValues(), [], $form->getFiles()
+            $form->getMethod(), $form->getUri(), $form->getPhpValues(), [], $formFiles
         );
     }
+
 
     /**
      * Get the content from the reponse.
@@ -145,5 +149,28 @@ trait LaravelTestCase
         $message .= "\n\n{$exception} on {$location}";
 
         throw new PHPUnitException($message);
+    }
+
+    /**
+     * Converts form files to UploadedFile instances for testing
+     *
+     * @param Form $form
+     * @return array
+     */
+    protected function convertFormFiles(Form $form)
+    {
+        $formFiles = $form->getFiles();
+        $uploadedFiles = $this->files;
+
+        $names = array_keys($formFiles);
+
+        $formFiles = array_map(function (array $file, $name) use ($uploadedFiles) {
+            if (isset($uploadedFiles[$name])) {
+                $absolutePath = $uploadedFiles[$name];
+                $file = new UploadedFile($file['tmp_name'], basename($absolutePath), $file['type'], $file['size'], $file['error'], true);
+            }
+            return $file;
+        }, $formFiles, $names);
+        return array_combine($names, $formFiles);
     }
 }


### PR DESCRIPTION
This creates `UploadedFile` instances with `$test=true`, which addresses the testing capabilities of `UploadedFile`
