### PR TITLE
Updated selector string

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -585,7 +585,7 @@ trait IntegrationTrait
     {
         $name = str_replace('#', '', $name);
 
-        return $this->crawler->filter("{$element}#{$name}, {$element}[name={$name}]");
+        return $this->crawler->filter("{$element}#{$name}, {$element}[name='{$name}']");
     }
 
     /**


### PR DESCRIPTION
Fixes an issue when trying to select an element that has brackets in its attribute. 

(See https://github.com/laravel/framework/issues/9090 for an example).
