### PR TITLE
reset bindings and wheres after execute

### DIFF
--- a/src/Database/Adapter.php
+++ b/src/Database/Adapter.php
@@ -99,6 +99,9 @@ class Adapter
     protected function execute($query)
     {
         $query->execute($this->bindings);
+        
+        $this->bindings = [];
+        $this->wheres   = [];
 
         return $query;
     }


### PR DESCRIPTION
I've a test where I insert data in multiple tables. When calling the `verifyInDatabase` multiple times I got some errors.

My Code looked like this:

``` php
public function it_creates_something()
{
  $this->doesSomethingThatInsertsData();

  $this->verifyInDatabase('tableOne', [
    'fieldA' => 'a',
    'fieldB' => 'b',
  ]);

  $this->verifyInDatabase('tableTwo', [
    'fieldC' => 'c',
    'fieldD' => 'd',
  ]);
}
```

The second `verifyInDatabase` would also check for `fieldA` and `fieldB`.
