### PR TITLE
close browser before opening another one

### DIFF
--- a/src/Extensions/Selenium.php
+++ b/src/Extensions/Selenium.php
@@ -64,6 +64,7 @@ abstract class Selenium extends \PHPUnit_Framework_TestCase implements Emulator,
     protected function makeRequest($requestType, $uri, $parameters = [])
     {
         try {
+            $this->closeBrowser();
             $this->session = $this->newSession()->open($uri);
             $this->updateCurrentUrl();
         } catch (CurlExec $e) {


### PR DESCRIPTION
When running the following test, you will see two browser windows. One of them wont be closed after the test.

``` php
$this->visit('/createSomething')
     ->submitForm('Save', ['name' => 'Jonny'])
     ->visit('/overview')
     ->see('Jonny');
```
