### PR TITLE
Added uncheck (with untick alias) for #105

### DIFF
--- a/src/Extensions/IntegrationTrait.php
+++ b/src/Extensions/IntegrationTrait.php
@@ -282,9 +282,20 @@ trait IntegrationTrait
      * @param  string $element
      * @return static
      */
-    public function check($element)
+    public function check($element, $toCheck = true)
     {
-        return $this->storeInput($element, true);
+        return $this->storeInput($element, $toCheck);
+    }
+
+    /**
+     * Uncheck a checkbox.
+     *
+     * @param  string $element
+     * @return static
+     */
+    public function uncheck($element)
+    {
+        return $this->check($element, false);
     }
 
     /**
@@ -293,9 +304,20 @@ trait IntegrationTrait
      * @param  string $element
      * @return static
      */
-    public function tick($element)
+    public function tick($element, $toCheck = true)
     {
-        return $this->check($element);
+        return $this->check($element, $toCheck);
+    }
+
+    /**
+     * Alias that defers to uncheck method.
+     *
+     * @param  string $element
+     * @return static
+     */
+    public function untick($element)
+    {
+        return $this->uncheck($element);
     }
 
     /**


### PR DESCRIPTION
Allowed to uncheck checkboxes.

I assumed someone would also like to check with false using the standard check method as the following example:

``` php
$this->check('box', false);
```

What do you think about that, though?
