### PR TITLE
bump fabpot/goutte to v3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "laracasts/testdummy": "~2.1",
         "symfony/dom-crawler": "~2.5",
         "symfony/css-selector": "~2.5",
-        "fabpot/goutte": "~2.0",
+        "fabpot/goutte": "~3.1",
         "instaclick/php-webdriver": "~1.4"
     },
     "autoload": {


### PR DESCRIPTION
Latest verion of `fabpot/goutte` is `3.1.1` 

In many cases it now does not allow to have your package and `fabpot/goutte` installed in same project...
