### PR TITLE
fix select method issue with duplicate option values

### DIFF
--- a/src/Extensions/Selenium.php
+++ b/src/Extensions/Selenium.php
@@ -240,7 +240,7 @@ abstract class Selenium extends \PHPUnit_Framework_TestCase implements Emulator,
      * @param  string $element
      * @return static
      */
-    public function select($option, $element)
+    public function select($element, $option)
     {
         $this->findByValue($option, "select[name=$element] > option")->click();
 

--- a/src/Extensions/Selenium.php
+++ b/src/Extensions/Selenium.php
@@ -236,13 +236,13 @@ abstract class Selenium extends \PHPUnit_Framework_TestCase implements Emulator,
     /**
      * Select an option from a dropdown.
      *
-     * @param  string $element
      * @param  string $option
+     * @param  string $element
      * @return static
      */
-    public function select($element, $option)
+    public function select($option, $element)
     {
-        $this->findByValue($option, 'option')->click();
+        $this->findByValue($option, "select[name=$element] > option")->click();
 
         return $this;
     }


### PR DESCRIPTION
´´´
InvalidArgumentException: Crap. Couldn't find an option with a 'value' attribute of 
´´´

should now work with duplicate dropdown (option) values within different select elements
