### PR TITLE
set crawler after form submission

### DIFF
--- a/src/Extensions/Goutte.php
+++ b/src/Extensions/Goutte.php
@@ -48,7 +48,7 @@ abstract class Goutte extends \PHPUnit_Framework_TestCase implements Emulator
      */
     public function submitForm($buttonText, $formData = null)
     {
-        $this->client()->submit(
+        $this->crawler = $this->client()->submit(
             $this->fillForm($buttonText, $formData)
         );
 


### PR DESCRIPTION
In order to support onPage() after submitForm() or press() the crawler needs to be updated to use the DOM from the page returned from the form submission.
